### PR TITLE
[BUGFIX] Apply padding-right only from sm breakpoint

### DIFF
--- a/Resources/Private/Partials/Review/Item.html
+++ b/Resources/Private/Partials/Review/Item.html
@@ -2,7 +2,7 @@
 <div class="col-sm-12 mb-3 review">
     <div class="d-sm-flex text-center text-sm-left">
         <f:if condition="{settings.showAuthorProfilePhoto} == 1">
-            <div class="pr-4 img-wrapper">
+            <div class="pr-sm-4 img-wrapper">
                 <img src="{review.profile_photo_url}" width="{settings.authorPhotoWidth}" alt="{review.author_name}"
                      loading="lazy" />
             </div>


### PR DESCRIPTION
Previously, `pr-4` was applied to the image wrapper unconditionally, which meant that spacing was added on the right even when the image was centered above the text on small screens. This resulted in an undesirable offset when centering the image.